### PR TITLE
Add measurement-system preferences and canonical ingredient unit handling

### DIFF
--- a/app/src/main/java/com/example/cooking/ui/activities/AiChatActivity.java
+++ b/app/src/main/java/com/example/cooking/ui/activities/AiChatActivity.java
@@ -1,8 +1,14 @@
 package com.example.cooking.ui.activities;
 
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.inputmethod.EditorInfo;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -15,10 +21,11 @@ import com.example.cooking.domain.entities.Message;
 import com.example.cooking.ui.adapters.MessageAdapter;
 import com.example.cooking.ui.viewmodels.AiChatViewModel;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class AiChatActivity extends AppCompatActivity {
     public static final String EXTRA_CONTEXT_RECIPE_ID = "context_recipe_id";
@@ -28,6 +35,10 @@ public class AiChatActivity extends AppCompatActivity {
     private MessageAdapter messageAdapter;
     private TextInputEditText editTextMessage;
     private FloatingActionButton buttonSend;
+    private LinearLayout loadingStatusContainer;
+    private CircularProgressIndicator loadingStatusIndicator;
+    private TextView loadingStatusText;
+    private List<Message> currentMessages;
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -77,11 +88,16 @@ public class AiChatActivity extends AppCompatActivity {
 
         recyclerViewMessages = findViewById(R.id.recyclerViewMessages);
         messageAdapter = new MessageAdapter();
-        recyclerViewMessages.setLayoutManager(new LinearLayoutManager(this));
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this);
+        layoutManager.setStackFromEnd(true);
+        recyclerViewMessages.setLayoutManager(layoutManager);
         recyclerViewMessages.setAdapter(messageAdapter);
 
         editTextMessage = findViewById(R.id.editTextMessage);
         buttonSend = findViewById(R.id.buttonSend);
+        loadingStatusContainer = findViewById(R.id.loadingStatusContainer);
+        loadingStatusIndicator = findViewById(R.id.loadingStatusIndicator);
+        loadingStatusText = findViewById(R.id.loadingStatusText);
 
         setupObservers();
         setupEventListeners();
@@ -95,18 +111,19 @@ public class AiChatActivity extends AppCompatActivity {
 
     private void setupObservers() {
         viewModel.getMessages().observe(this, messageList -> {
+            currentMessages = messageList;
             messageAdapter.submitList(messageList);
             if (messageList != null && !messageList.isEmpty()) {
                 recyclerViewMessages.scrollToPosition(messageList.size() - 1);
             }
+            updateLoadingState();
         });
         
-        viewModel.getIsLoading().observe(this, loading ->
-            buttonSend.setEnabled(!loading && Boolean.TRUE.equals(viewModel.getCanSend().getValue()))
-        );
-        viewModel.getCanSend().observe(this, canSend ->
-            buttonSend.setEnabled(Boolean.TRUE.equals(canSend) && !Boolean.TRUE.equals(viewModel.getIsLoading().getValue()))
-        );
+        viewModel.getIsLoading().observe(this, loading -> {
+            updateSendAvailability();
+            updateLoadingState();
+        });
+        viewModel.getCanSend().observe(this, canSend -> updateSendAvailability());
         
         viewModel.getShowMessage().observe(this, message -> {
             if (message != null) {
@@ -117,17 +134,90 @@ public class AiChatActivity extends AppCompatActivity {
     }
 
     private void setupEventListeners() {
-        buttonSend.setOnClickListener(v -> {
-            String text = editTextMessage.getText().toString().trim();
-            if (!text.isEmpty()) {
-                buttonSend.setEnabled(false);
-                if (viewModel.sendMessage(text)) {
-                    editTextMessage.setText("");
-                } else {
-                    buttonSend.setEnabled(Boolean.TRUE.equals(viewModel.getCanSend().getValue())
-                            && !Boolean.TRUE.equals(viewModel.getIsLoading().getValue()));
-                }
+        editTextMessage.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                updateSendAvailability();
             }
         });
+
+        editTextMessage.setOnEditorActionListener((v, actionId, event) -> {
+            boolean imeSend = actionId == EditorInfo.IME_ACTION_SEND
+                    || actionId == EditorInfo.IME_ACTION_DONE;
+            boolean hardwareEnter = actionId == EditorInfo.IME_NULL
+                    && event != null
+                    && event.getAction() == KeyEvent.ACTION_DOWN
+                    && event.getKeyCode() == KeyEvent.KEYCODE_ENTER
+                    && !event.isShiftPressed();
+            if (!imeSend && !hardwareEnter) {
+                return false;
+            }
+            return trySendMessage();
+        });
+
+        buttonSend.setOnClickListener(v -> trySendMessage());
+        updateSendAvailability();
+    }
+
+    private boolean trySendMessage() {
+        String text = getTrimmedMessage();
+        if (text.isEmpty()) {
+            updateSendAvailability();
+            return false;
+        }
+        if (!viewModel.sendMessage(text)) {
+            updateSendAvailability();
+            return false;
+        }
+        editTextMessage.setText("");
+        updateSendAvailability();
+        return true;
+    }
+
+    private String getTrimmedMessage() {
+        Editable editable = editTextMessage.getText();
+        return editable == null ? "" : editable.toString().trim();
+    }
+
+    private void updateSendAvailability() {
+        boolean enabled = !getTrimmedMessage().isEmpty()
+                && Boolean.TRUE.equals(viewModel.getCanSend().getValue());
+        buttonSend.setEnabled(enabled);
+        buttonSend.setAlpha(enabled ? 1f : 0.38f);
+    }
+
+    private void updateLoadingState() {
+        boolean isLoading = Boolean.TRUE.equals(viewModel.getIsLoading().getValue());
+        if (!isLoading) {
+            loadingStatusContainer.setVisibility(LinearLayout.GONE);
+            return;
+        }
+
+        boolean hasPendingAssistantReply = false;
+        if (currentMessages != null) {
+            for (Message message : currentMessages) {
+                Message.MessageType type = message.getType();
+                if (type == Message.MessageType.LOADING || type == Message.MessageType.RECIPE_FLOW_LOADING) {
+                    hasPendingAssistantReply = true;
+                    break;
+                }
+            }
+        }
+
+        loadingStatusContainer.setVisibility(LinearLayout.VISIBLE);
+        loadingStatusIndicator.show();
+        loadingStatusText.setText(
+                hasPendingAssistantReply
+                        ? R.string.ai_chat_status_generating
+                        : R.string.ai_chat_status_syncing
+        );
     }
 }

--- a/app/src/main/java/com/example/cooking/ui/adapters/MessageAdapter.java
+++ b/app/src/main/java/com/example/cooking/ui/adapters/MessageAdapter.java
@@ -3,8 +3,6 @@ package com.example.cooking.ui.adapters;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.Intent;
 import android.widget.FrameLayout;
 import android.view.Gravity;
@@ -24,8 +22,6 @@ import com.example.cooking.domain.entities.Message.MessageType;
 import com.example.cooking.ui.activities.RecipeDetailActivity;
 import com.example.cooking.ui.adapters.Recipe.RecipeListAdapter;
 import com.example.cooking.ui.utils.MarkdownUtils;
-
-import android.app.Activity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +48,7 @@ public class MessageAdapter extends ListAdapter<Message, RecyclerView.ViewHolder
 
         @Override
         public boolean areContentsTheSame(@NonNull Message oldItem, @NonNull Message newItem) {
-            return oldItem.getType() == newItem.getType()
+            return Objects.equals(oldItem.getType(), newItem.getType())
                     && Objects.equals(oldItem.getText(), newItem.getText())
                     && Objects.equals(oldItem.getSecondaryText(), newItem.getSecondaryText())
                     && oldItem.isUser() == newItem.isUser()
@@ -205,8 +201,15 @@ public class MessageAdapter extends ListAdapter<Message, RecyclerView.ViewHolder
             if (recipe == null) {
                 return;
             }
-            titleView.setText(recipe.getTitle());
+            String recipeTitle = recipe.getTitle();
+            titleView.setText(recipeTitle);
             subtitleView.setText(subtitle);
+            String contentDescription = itemView.getContext().getString(
+                    R.string.chat_created_recipe_card_description,
+                    recipeTitle
+            );
+            imageView.setContentDescription(contentDescription);
+            cardView.setContentDescription(contentDescription);
             if (recipe.getPhoto_url() != null && !recipe.getPhoto_url().isEmpty()) {
                 Glide.with(itemView)
                         .load(recipe.getPhoto_url())
@@ -221,8 +224,7 @@ public class MessageAdapter extends ListAdapter<Message, RecyclerView.ViewHolder
             cardView.setOnClickListener(v -> {
                 Intent intent = new Intent(v.getContext(), RecipeDetailActivity.class);
                 intent.putExtra(RecipeDetailActivity.EXTRA_SELECTED_RECIPE, recipe);
-                Activity activity = (Activity) v.getContext();
-                activity.startActivityForResult(intent, 200);
+                v.getContext().startActivity(intent);
             });
         }
     }

--- a/app/src/main/java/com/example/cooking/ui/viewmodels/AiChatViewModel.java
+++ b/app/src/main/java/com/example/cooking/ui/viewmodels/AiChatViewModel.java
@@ -23,9 +23,35 @@ import com.google.firebase.auth.FirebaseUser;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 public class AiChatViewModel extends AndroidViewModel {
+    private static final String[] RECIPE_REFERENCE_KEYWORDS = {
+            "recipe",
+            "\u0440\u0435\u0446\u0435\u043f\u0442"
+    };
+    private static final String[] RECIPE_CREATION_KEYWORDS = {
+            "\u0441\u043e\u0437\u0434",
+            "\u0441\u0433\u0435\u043d\u0435\u0440",
+            "\u043f\u0440\u0438\u0434\u0443\u043c",
+            "\u0445\u043e\u0447\u0443",
+            "\u0441\u0434\u0435\u043b\u0430\u0439",
+            "\u043f\u0440\u0438\u0433\u043e\u0442\u043e\u0432",
+            "creat",
+            "generat",
+            "want",
+            "make",
+            "cook"
+    };
+    private static final String[] CREATED_RECIPE_PHRASES = {
+            "\u0441\u043e\u0437\u0434\u0430\u043b \u0440\u0435\u0446\u0435\u043f\u0442",
+            "\u0433\u043e\u0442\u043e\u0432\u043e",
+            "\u044f \u0441\u043e\u0437\u0434\u0430\u043b",
+            "created a recipe",
+            "here's your recipe"
+    };
+
     private final MutableLiveData<List<Message>> messages = new MutableLiveData<>(new ArrayList<>());
     private final MutableLiveData<Boolean> isLoading = new MutableLiveData<>(false);
     private final MutableLiveData<Boolean> canSend = new MutableLiveData<>(true);
@@ -55,6 +81,7 @@ public class AiChatViewModel extends AndroidViewModel {
         super(application);
         chatRepository = new ChatRepository(application);
         recipeLocalRepository = new RecipeLocalRepository(application);
+        messages.setValue(createWelcomeMessages());
         loadHistory(false);
     }
 
@@ -84,9 +111,7 @@ public class AiChatViewModel extends AndroidViewModel {
             isLoading.setValue(false);
             if (response != null && response.getMessageCount() == 0) {
                 if (shouldReplaceWithHistory(Collections.emptyList(), mergeWithCurrent)) {
-                    List<Message> welcome = new ArrayList<>();
-                    welcome.add(new Message(getApplication().getString(R.string.chat_welcome), false));
-                    messages.setValue(welcome);
+                    messages.setValue(createWelcomeMessages());
                 }
             } else if (response != null && response.getMessages() != null) {
                 AppExecutors.getInstance().diskIO().execute(() -> {
@@ -144,7 +169,8 @@ public class AiChatViewModel extends AndroidViewModel {
         pendingHistoryRefreshAttempts = 0;
         clearPendingHistoryRefreshes();
         activeHistoryLoadId = null;
-        inFlightRequestId = UUID.randomUUID().toString();
+        final String requestId = UUID.randomUUID().toString();
+        inFlightRequestId = requestId;
         canSend.setValue(false);
         List<Message> currentMessages = getCurrentMessages();
         currentMessages.add(new Message(text, true));
@@ -162,10 +188,17 @@ public class AiChatViewModel extends AndroidViewModel {
         messages.setValue(currentMessages);
         isLoading.setValue(true);
 
-        if (messageLiveData != null && messageObserver != null) {
-            messageLiveData.removeObserver(messageObserver);
-        }
+        clearActiveMessageRequest();
+        inFlightRequestId = requestId;
         messageObserver = response -> {
+            if (!requestId.equals(inFlightRequestId)) {
+                return;
+            }
+            if (messageLiveData != null && messageObserver != null) {
+                messageLiveData.removeObserver(messageObserver);
+                messageLiveData = null;
+                messageObserver = null;
+            }
             isLoading.setValue(false);
             List<Message> updatedMessages = getCurrentMessages();
             boolean removedLoading = false;
@@ -227,7 +260,7 @@ public class AiChatViewModel extends AndroidViewModel {
                 }
             }
         };
-        messageLiveData = chatRepository.sendChatMessage(text, contextualRecipeId, inFlightRequestId);
+        messageLiveData = chatRepository.sendChatMessage(text, contextualRecipeId, requestId);
         messageLiveData.observeForever(messageObserver);
         return true;
     }
@@ -236,22 +269,9 @@ public class AiChatViewModel extends AndroidViewModel {
         if (recipeFlowActive) {
             return true;
         }
-        if (messageText == null) {
-            return false;
-        }
-        String normalized = messageText.toLowerCase();
-        return (normalized.contains("рецепт") || normalized.contains("recipe"))
-                && (normalized.contains("созд")
-                || normalized.contains("сгенер")
-                || normalized.contains("придум")
-                || normalized.contains("хочу")
-                || normalized.contains("сделай")
-                || normalized.contains("приготов")
-                || normalized.contains("creat")
-                || normalized.contains("generat")
-                || normalized.contains("want")
-                || normalized.contains("make")
-                || normalized.contains("cook"));
+        String normalized = normalizeForMatching(messageText);
+        return containsAny(normalized, RECIPE_REFERENCE_KEYWORDS)
+                && containsAny(normalized, RECIPE_CREATION_KEYWORDS);
     }
 
     private List<Message> buildMessagesFromHistory(List<ChatMessage> historyMessages) {
@@ -354,12 +374,7 @@ public class AiChatViewModel extends AndroidViewModel {
         if ("hero".equalsIgnoreCase(recipePresentation)) {
             return true;
         }
-        if (messageText == null) {
-            return false;
-        }
-        String normalized = messageText.toLowerCase();
-        return normalized.contains("создал рецепт") || normalized.contains("готово! я создал")
-                || normalized.contains("created a recipe") || normalized.contains("here's your recipe");
+        return containsAny(normalizeForMatching(messageText), CREATED_RECIPE_PHRASES);
     }
 
     private List<Recipe> resolveRecipes(List<Integer> recipeIds) {
@@ -418,7 +433,7 @@ public class AiChatViewModel extends AndroidViewModel {
         final Runnable[] refreshHolder = new Runnable[1];
         refreshHolder[0] = () -> {
             pendingHistoryRefreshRunnables.remove(refreshHolder[0]);
-            refreshHistory();
+            loadHistory(true);
         };
         pendingHistoryRefreshRunnables.add(refreshHolder[0]);
         mainHandler.postDelayed(refreshHolder[0], pendingHistoryRefreshAttempts == 1 ? 750L : 1500L);
@@ -456,21 +471,30 @@ public class AiChatViewModel extends AndroidViewModel {
     }
 
     public void clearChat() {
-          FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+        FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
         if (currentUser == null) {
             List<Message> temp = getCurrentMessages();
             temp.add(new Message(getApplication().getString(R.string.error_need_auth), false));
             messages.setValue(temp);
             return;
         }
-        
+
         isLoading.setValue(true);
+        canSend.setValue(false);
+        clearPendingHistoryRefreshes();
+        pendingHistoryRefreshAttempts = 0;
+        activeHistoryLoadId = null;
+        clearActiveMessageRequest();
+        clearActiveClearChatObserver();
         clearChatObserver = response -> {
+            if (clearChatLiveData != null && clearChatObserver != null) {
+                clearChatLiveData.removeObserver(clearChatObserver);
+                clearChatLiveData = null;
+                clearChatObserver = null;
+            }
             isLoading.setValue(false);
             if (response != null && response.isSuccess()) {
-                List<Message> welcomeList = new ArrayList<>();
-                welcomeList.add(new Message(getApplication().getString(R.string.chat_welcome), false));
-                messages.setValue(welcomeList);
+                messages.setValue(createWelcomeMessages());
                 recipeFlowActive = false;
                 inFlightRequestId = null;
                 canSend.setValue(true);
@@ -484,6 +508,42 @@ public class AiChatViewModel extends AndroidViewModel {
         clearChatLiveData.observeForever(clearChatObserver);
     }
 
+    private void clearActiveMessageRequest() {
+        if (messageLiveData != null && messageObserver != null) {
+            messageLiveData.removeObserver(messageObserver);
+        }
+        messageLiveData = null;
+        messageObserver = null;
+        inFlightRequestId = null;
+    }
+
+    private void clearActiveClearChatObserver() {
+        if (clearChatLiveData != null && clearChatObserver != null) {
+            clearChatLiveData.removeObserver(clearChatObserver);
+        }
+        clearChatLiveData = null;
+        clearChatObserver = null;
+    }
+
+    private String normalizeForMatching(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.toLowerCase(Locale.ROOT);
+    }
+
+    private boolean containsAny(String text, String[] keywords) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     @Override
     protected void onCleared() {
@@ -491,15 +551,17 @@ public class AiChatViewModel extends AndroidViewModel {
         if (historyLiveData != null && historyObserver != null) {
             historyLiveData.removeObserver(historyObserver);
         }
-        if (messageLiveData != null && messageObserver != null) {
-            messageLiveData.removeObserver(messageObserver);
-        }
-        if (clearChatLiveData != null && clearChatObserver != null) {
-            clearChatLiveData.removeObserver(clearChatObserver);
-        }
+        clearActiveMessageRequest();
+        clearActiveClearChatObserver();
         clearPendingHistoryRefreshes();
         if (cooldownRunnable != null) {
             mainHandler.removeCallbacks(cooldownRunnable);
         }
+    }
+
+    private List<Message> createWelcomeMessages() {
+        List<Message> welcome = new ArrayList<>();
+        welcome.add(new Message(getApplication().getString(R.string.chat_welcome_with_bugs), false));
+        return welcome;
     }
 }

--- a/app/src/main/res/layout/activity_ai_chat.xml
+++ b/app/src/main/res/layout/activity_ai_chat.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/md_theme_background">
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
@@ -26,6 +25,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:baselineAligned="false"
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:paddingHorizontal="12dp"
@@ -36,6 +36,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:baselineAligned="false"
             android:orientation="horizontal"
             android:gravity="center_vertical"
             android:background="@drawable/bg_chat_input_pill"
@@ -49,7 +50,8 @@
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
                 android:hint="@string/ai_chat_message_hint"
-                android:inputType="textMultiLine"
+                android:imeOptions="actionSend"
+                android:inputType="textCapSentences|textMultiLine"
                 android:minLines="1"
                 android:maxLines="5"
                 android:scrollHorizontally="false"
@@ -59,9 +61,10 @@
 
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/buttonSend"
-                android:layout_width="38dp"
-                android:layout_height="38dp"
-                app:fabCustomSize="38dp"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:alpha="0.38"
+                app:fabCustomSize="44dp"
                 app:shapeAppearanceOverlay="@style/RoundedButton"
                 app:srcCompat="@drawable/send"
                 app:backgroundTint="@color/md_theme_primary"
@@ -69,6 +72,35 @@
                 android:contentDescription="@string/ai_chat_send_button_description" />
 
         </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/loadingStatusContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="12dp"
+        android:visibility="gone">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/loadingStatusIndicator"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:indeterminate="true"
+            app:indicatorColor="@color/md_theme_primary"
+            app:indicatorSize="18dp"
+            app:trackThickness="2dp" />
+
+        <TextView
+            android:id="@+id/loadingStatusText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:textColor="@color/md_theme_onSurfaceVariant"
+            android:textSize="13sp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/menu/chat_toolbar_menu.xml
+++ b/app/src/main/res/menu/chat_toolbar_menu.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@+id/action_clear_chat"
         android:icon="@drawable/ic_delete"
-        android:title="Очистить чат"
+        android:title="@string/chat_clear_action"
         app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -128,6 +128,8 @@
     <string name="ai_chat_message_hint">Введите сообщение</string>
     <string name="ai_chat_title">Кулинарный ассистент</string>
     <string name="ai_chat_send_button_description">Отправка сообщения</string>
+    <string name="ai_chat_status_generating">Ассистент готовит ответ…</string>
+    <string name="ai_chat_status_syncing">Обновляю диалог…</string>
 
     <!-- Add Recipe Activity -->
     <string name="add_recipe_image_label">Изображение рецепта*</string>
@@ -300,6 +302,7 @@
     <string name="profile_delete_account_message">Вы действительно хотите удалить аккаунт? Это действие необратимо.\n\nВведите пароль для подтверждения:</string>
     <string name="action_open_chat">Открыть чат</string>
     <string name="action_close">Закрыть</string>
+    <string name="chat_clear_action">Очистить чат</string>
     <string name="chat_clear_title">Очистить чат?</string>
     <string name="chat_clear_message">Вы уверены, что хотите очистить чат?</string>
     <string name="shared_profile_default_name">Профиль</string>
@@ -408,4 +411,5 @@
     <string name="chat_recipe_flow_loading_title">Собираю ваш рецепт</string>
     <string name="chat_recipe_flow_loading_subtitle">Уточняю детали, подбираю рецепт и готовлю красивую карточку результата.</string>
     <string name="chat_created_recipe_subtitle">ИИ создал этот рецепт для вас. Нажмите, чтобы открыть.</string>
-</resources> 
+    <string name="chat_created_recipe_card_description">Открыть рецепт %1$s</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,8 @@
     <string name="ai_chat_message_hint">Enter a message</string>
     <string name="ai_chat_title">Culinary Assistant</string>
     <string name="ai_chat_send_button_description">Send message</string>
+    <string name="ai_chat_status_generating">Assistant is preparing a reply…</string>
+    <string name="ai_chat_status_syncing">Updating conversation…</string>
 
     <!-- Add Recipe Activity -->
     <string name="add_recipe_image_label">Recipe image*</string>
@@ -301,6 +303,7 @@
     <string name="profile_delete_account_message">Are you sure you want to delete your account? This action is irreversible.\n\nEnter your password to confirm:</string>
     <string name="action_open_chat">Open chat</string>
     <string name="action_close">Close</string>
+    <string name="chat_clear_action">Clear chat</string>
     <string name="chat_clear_title">Clear chat?</string>
     <string name="chat_clear_message">Are you sure you want to clear the chat?</string>
     <string name="shared_profile_default_name">Profile</string>
@@ -409,4 +412,5 @@
     <string name="chat_recipe_flow_loading_title">Working on your recipe</string>
     <string name="chat_recipe_flow_loading_subtitle">Clarifying the details, preparing the recipe, and getting everything ready.</string>
     <string name="chat_created_recipe_subtitle">AI created this recipe for you. Tap to open it.</string>
+    <string name="chat_created_recipe_card_description">Open recipe %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add a local measurement-system preference with `original`, `metric`, and `imperial` display modes.
- Introduce a unit domain layer for normalization, conversion, and formatting of ingredient amounts.
- Preserve legacy ingredient data while rendering recipe details through the new formatter.
- Update ingredient editing, validation, and persistence paths to work with canonical unit codes.
- Include unit tests for legacy normalization and formatting behavior.

## Testing
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat assembleDebug`